### PR TITLE
Make tests work on Linux, always populate code property

### DIFF
--- a/lib/socketCodesMap.js
+++ b/lib/socketCodesMap.js
@@ -1,4 +1,5 @@
 module.exports = {
+    EADDRINFO: 502,
     ECONNABORTED: 502,
     ECONNREFUSED: 504,
     ECONNRESET: 502,

--- a/lib/socketErrors.js
+++ b/lib/socketErrors.js
@@ -6,7 +6,8 @@ function createSocketError(errorCode) {
     var statusCode = socketCodesMap[errorCode] || 'Unknown';
 
     return socketErrors[errorCode] = createError({
-        name: errorCode
+        name: errorCode,
+        code: errorCode
     }, httpErrors[statusCode]);
 }
 

--- a/test/socketErrors.js
+++ b/test/socketErrors.js
@@ -8,7 +8,7 @@ describe('socketErrors', function () {
 
     it('will create a properly subclassed instance', function (done) {
         // capture a genuine ECONNREFUSED error
-        http.get('nonexistent').on('error', function (err) {
+        http.get('http://localhost:59891/').on('error', function (err) {
             var socketError = socketErrors(err);
             var httpError = new httpErrors[504]();
 

--- a/test/socketErrors.js
+++ b/test/socketErrors.js
@@ -74,6 +74,21 @@ describe('socketErrors', function () {
 
                 expect(socketError.statusCode, 'to equal', statusCode);
             });
+
+            it('lets the `code` from the original instance take precedence over the one built into the class', function () {
+                var socketError = socketErrors((function () {
+                    var err = new Error();
+                    err.code = 'SOMETHINGELSE';
+                    return err;
+                })());
+                expect(socketError.code, 'to equal', 'SOMETHINGELSE');
+            });
+
+            describe('when instantiated via the constructor', function () {
+                it('has a `code` property', function () {
+                    expect(new socketErrors[errorCode]().code, 'to equal', errorCode);
+                });
+            });
         });
     });
 

--- a/test/socketErrors.js
+++ b/test/socketErrors.js
@@ -1,5 +1,5 @@
 var expect = require('unexpected');
-var httpErrors = require('httpErrors');
+var httpErrors = require('httperrors');
 var http = require('http');
 var socketCodesMap = require('../lib/socketCodesMap');
 var socketErrors = require('../lib/socketErrors');


### PR DESCRIPTION
While reviewing https://github.com/One-com/beanbag/pull/2 I found out that I would like the directly created `socketError` instances to have the `code` property so one of the tests could be changed:

``` diff
     it('should handle ECONNREFUSED', function () {
-        var error = new Error('connect ECONNREFUSED');
-        error.code = 'ECONNREFUSED';
-
         return expect(function (cb) {
             new BeanBag({ url: 'http://localhost:5984/' }).request({ path: 'foo' }, cb);
         }, 'with http mocked out', {
             response: error
-        }, 'to call the callback with error', socketErrors(error));
+        }, 'to call the callback with error', new socketErrors.ECONNREFUSED('connect ECONNREFUSED'));
     });
```
