### PR TITLE
Add a socketErrors.SocketError that all socket errors are instances of.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ node-socketerrors
 [![NPM version](https://badge.fury.io/js/socketerrors.svg)](http://badge.fury.io/js/socketerrors)
 [![Build Status](https://travis-ci.org/alexjeffburke/node-socketerrors.svg?branch=master)](https://travis-ci.org/alexjeffburke/unode-socketerrors)
 
-Exposes a function mapping socket errors to SocketError objects subclassing
-<a href="https://github.com/One-com/node-httperrors">httperrors</a>.
+Exposes a function mapping socket errors to SocketError objects.
 
 The defined SocketError objects are created via
 <a href="https://github.com/One-com/node-createerror">createerror</a>.

--- a/lib/socketErrors.js
+++ b/lib/socketErrors.js
@@ -1,14 +1,25 @@
 var createError = require('createerror');
 var httpErrors = require('httperrors');
 var socketCodesMap = require('./socketCodesMap');
+var _ = require('lodash');
+
+var SocketError = createError({ name: 'SocketError' });
 
 function createSocketError(errorCode) {
     var statusCode = socketCodesMap[errorCode] || 'Unknown';
 
-    return socketErrors[errorCode] = createError({
+    var options = _.defaults({
         name: errorCode,
-        code: errorCode
-    }, httpErrors[statusCode]);
+        code: errorCode,
+        statusCode: statusCode,
+        status: statusCode
+    }, _.omit(httpErrors(statusCode), 'message'));
+
+    var socketError = createError(options, SocketError);
+
+    socketErrors[errorCode] = socketError;
+
+    return socketError;
 }
 
 var socketErrors = module.exports = function (err) {
@@ -22,6 +33,8 @@ var socketErrors = module.exports = function (err) {
 
     return new socketErrors[errorName](err);
 };
+
+module.exports.SocketError = SocketError;
 
 // create an Unknown error sentinel
 socketErrors.NotSocketError = createSocketError('NotSocketError');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "license": "BSD",
   "dependencies": {
     "createerror": "1.0.0",
-    "httperrors": "0.7.1"
+    "httperrors": "1.2.0",
+    "lodash": "3.10.1"
   },
   "devDependencies": {
     "mocha": "2.2.5",

--- a/test/socketErrors.js
+++ b/test/socketErrors.js
@@ -23,6 +23,8 @@ describe('socketErrors', function () {
             // has named errorCode property
             expect(socketError[err.code], 'to be true');
 
+            expect(socketError, 'to be a', socketErrors.SocketError);
+
             done();
         });
     });


### PR DESCRIPTION
Change each socket error class to inherit parasitically from the mapped-to HTTP error instance so that it's not actually an instance of an HTTP error.

This will be handy when using Bluebird's `.catch()` method, eg.:

``` js
var teepee = require('teepee');
var httpErrors = teepee.httpErrors;
var socketErrors = teepee.socketErrors;
teepee('http://gofish.dk/')
    .catch(httpErrors.HttpError, function (err) {
        // ...
    })
    .catch(socketErrors.SocketError, function (err) {
        // ...
    })
    .then(function (response) { /* YAY */ });
```
